### PR TITLE
Fix/pylint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,12 @@
       ]
       # Naming Conventions
       argument_naming-style="snake_case"
-      attr-naming-style="camelCase"
+      attr-naming-style="snake_case"
       class-naming-style="PascalCase"
       class-attribute-naming-style="UPPER_CASE"
       const-naming-style="UPPER_CASE"
       function-naming-style="snake_case"
-      inlinevar-naming-style="camelCase"
+      inlinevar-naming-style="snake_case"
       method-naming-style="snake_case"
       module-naming-style="snake_case"
       variable-naming-style="snake_case"


### PR DESCRIPTION
As discussed [in another thread](https://github.com/MideTechnology/endaq-python-ide/pull/7#discussion_r679947597), the Python code style used for this repository is different from the rules laid out in [our styleguide](https://github.com/MideTechnology/MideStyleGuides/blob/master/python.md), particularly in naming conventions.

This PR thus aims to change the pylint configuration defined in `pyproject.toml` to match the style used in this project. If accepted, this should likely also be reflected in our other `endaq.*` repositories.

See [the pylint documentation on name types](http://pylint.pycqa.org/en/latest/user_guide/options.html#introduction) for reference.