### PR TITLE
Added version req. for pandas (>=1.3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.16.6
 ebmlite>=3.0.0
 idelib>=3.2.0
 jinja2
-pandas
+pandas>=1.3
 requests

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     "ebmlite>=3.0.0",
     "idelib>=3.2.0",
     "requests",
-    "pandas",
+    "pandas>=1.3",
     "jinja2",  # required for pandas.DataFrame.style
     ]
 


### PR DESCRIPTION
Trivial change to fix #32. Not sure how urgent it is; it needs to be done, but it'll only really affect people with an older version of pandas already installed.